### PR TITLE
Pass key and value in correct order to `validateRequiredInput`

### DIFF
--- a/main.go
+++ b/main.go
@@ -97,7 +97,7 @@ func validateRequiredInput(value, key string) error {
 }
 
 func validateRequiredInputWithOptions(value, key string, options []string) error {
-	if err := validateRequiredInput(key, value); err != nil {
+	if err := validateRequiredInput(value, key); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Overview

I guess we pass key and value in opposite order to `validateRequiredInput` func. There is no errors for now, but it would be nice to be fixed.

## Change

`validateRequiredInput(key, value)` -> `validateRequiredInput(value, key)`