### PR TITLE
Add support for xcodebuild additional options

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,19 +3,52 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:97fd4c6fa762de1ba30a1d341f5511cad56ca1487ca8b286bcdaf04a0358d12b"
   name = "github.com/bitrise-io/go-utils"
-  packages = ["colorstring","command","errorutil","log","pathutil","stringutil"]
+  packages = [
+    "colorstring",
+    "command",
+    "errorutil",
+    "log",
+    "pathutil",
+    "stringutil",
+  ]
+  pruneopts = ""
   revision = "f1da7139131b85ab2a4bd4ffacbdc889a40018a1"
 
 [[projects]]
   branch = "master"
+  digest = "1:b55ec0f1a7c0587dffc3696044dc90783531d5fd8ca8e21c3c4c032528127609"
   name = "github.com/bitrise-tools/go-xcode"
-  packages = ["models","utility","xcodebuild","xcpretty"]
+  packages = [
+    "models",
+    "utility",
+    "xcodebuild",
+    "xcpretty",
+  ]
+  pruneopts = ""
   revision = "c23fa74e7b04374fbff484fd12ba87cf64cd89e1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:63e7368fcf6b54804076eaec26fd9cf0c4466166b272393db4b93102e1e962df"
+  name = "github.com/kballard/go-shellquote"
+  packages = ["."]
+  pruneopts = ""
+  revision = "95032a82bc518f77982ea72343cc1ade730072f0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b83393da74abdf9dc224e336ea73f2fc04af05ba927393f7d780a249b2e4fa67"
+  input-imports = [
+    "github.com/bitrise-io/go-utils/command",
+    "github.com/bitrise-io/go-utils/log",
+    "github.com/bitrise-io/go-utils/pathutil",
+    "github.com/bitrise-io/go-utils/stringutil",
+    "github.com/bitrise-tools/go-xcode/utility",
+    "github.com/bitrise-tools/go-xcode/xcodebuild",
+    "github.com/bitrise-tools/go-xcode/xcpretty",
+    "github.com/kballard/go-shellquote",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -5,3 +5,7 @@
 [[constraint]]
   name = "github.com/bitrise-tools/go-xcode"
   branch = "master"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/kballard/go-shellquote"

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bitrise-tools/go-xcode/utility"
 	"github.com/bitrise-tools/go-xcode/xcodebuild"
 	"github.com/bitrise-tools/go-xcode/xcpretty"
+	"github.com/kballard/go-shellquote"
 )
 
 // ConfigsModel ...
@@ -28,6 +29,7 @@ type ConfigsModel struct {
 	IsCleanBuild string
 
 	GenerateCodeCoverageFiles string
+	XcodebuildOptions         string
 }
 
 func (configs ConfigsModel) print() {
@@ -43,6 +45,7 @@ func (configs ConfigsModel) print() {
 	log.Printf("- IsCleanBuild: %s", configs.IsCleanBuild)
 
 	log.Printf("- GenerateCodeCoverageFiles: %s", configs.GenerateCodeCoverageFiles)
+	log.Printf("- XcodebuildOptions: %s", configs.XcodebuildOptions)
 }
 
 func createConfigsModelFromEnvs() ConfigsModel {
@@ -57,6 +60,7 @@ func createConfigsModelFromEnvs() ConfigsModel {
 		IsCleanBuild: os.Getenv("is_clean_build"),
 
 		GenerateCodeCoverageFiles: os.Getenv("generate_code_coverage_files"),
+		XcodebuildOptions: os.Getenv("xcodebuild_options"),
 	}
 }
 
@@ -188,7 +192,7 @@ func main() {
 
 	fmt.Println()
 
-	// setup buildActios
+	// setup buildActions
 	buildAction := []string{}
 
 	if cleanBuild {
@@ -206,6 +210,14 @@ func main() {
 
 	if configs.Destination != "" {
 		testCommandModel.SetDestination(configs.Destination)
+	}
+
+	if configs.XcodebuildOptions != "" {
+		options, err := shellquote.Split(configs.XcodebuildOptions)
+		if err != nil {
+			failf("Failed to shell split XcodebuildOptions (%s), error: %s", configs.XcodebuildOptions)
+		}
+		testCommandModel.SetCustomOptions(options)
 	}
 
 	if configs.OutputTool == "xcpretty" {

--- a/step.yml
+++ b/step.yml
@@ -73,6 +73,15 @@ inputs:
     - xcpretty
     - xcodebuild
     is_required: true
+- xcodebuild_options: ""
+  opts:
+    title: Additional options for xcodebuild call
+    description: |-
+      Options added to the end of the xcodebuild call.
+
+      You can use multiple options, separated by a space
+      character. Example: `-xcconfig PATH -verbose`
+    is_required: false
 - workdir: $BITRISE_SOURCE_DIR
   opts:
     description: |

--- a/vendor/github.com/kballard/go-shellquote/LICENSE
+++ b/vendor/github.com/kballard/go-shellquote/LICENSE
@@ -1,0 +1,19 @@
+Copyright (C) 2014 Kevin Ballard
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/kballard/go-shellquote/README
+++ b/vendor/github.com/kballard/go-shellquote/README
@@ -1,0 +1,36 @@
+PACKAGE
+
+package shellquote
+    import "github.com/kballard/go-shellquote"
+
+    Shellquote provides utilities for joining/splitting strings using sh's
+    word-splitting rules.
+
+VARIABLES
+
+var (
+    UnterminatedSingleQuoteError = errors.New("Unterminated single-quoted string")
+    UnterminatedDoubleQuoteError = errors.New("Unterminated double-quoted string")
+    UnterminatedEscapeError      = errors.New("Unterminated backslash-escape")
+)
+
+
+FUNCTIONS
+
+func Join(args ...string) string
+    Join quotes each argument and joins them with a space. If passed to
+    /bin/sh, the resulting string will be split back into the original
+    arguments.
+
+func Split(input string) (words []string, err error)
+    Split splits a string according to /bin/sh's word-splitting rules. It
+    supports backslash-escapes, single-quotes, and double-quotes. Notably it
+    does not support the $'' style of quoting. It also doesn't attempt to
+    perform any other sort of expansion, including brace expansion, shell
+    expansion, or pathname expansion.
+
+    If the given input has an unterminated quoted string or ends in a
+    backslash-escape, one of UnterminatedSingleQuoteError,
+    UnterminatedDoubleQuoteError, or UnterminatedEscapeError is returned.
+
+

--- a/vendor/github.com/kballard/go-shellquote/both_test.go
+++ b/vendor/github.com/kballard/go-shellquote/both_test.go
@@ -1,0 +1,29 @@
+package shellquote
+
+import (
+	"reflect"
+	"testing"
+	"testing/quick"
+)
+
+// this is called bothtest because it tests Split and Join together
+
+func TestJoinSplit(t *testing.T) {
+	f := func(strs []string) bool {
+		// Join, then split, the input
+		combined := Join(strs...)
+		split, err := Split(combined)
+		if err != nil {
+			t.Logf("Error splitting %#v: %v", combined, err)
+			return false
+		}
+		if !reflect.DeepEqual(strs, split) {
+			t.Logf("Input %q did not match output %q", strs, split)
+			return false
+		}
+		return true
+	}
+	if err := quick.Check(f, nil); err != nil {
+		t.Error(err)
+	}
+}

--- a/vendor/github.com/kballard/go-shellquote/doc.go
+++ b/vendor/github.com/kballard/go-shellquote/doc.go
@@ -1,0 +1,3 @@
+// Shellquote provides utilities for joining/splitting strings using sh's
+// word-splitting rules.
+package shellquote

--- a/vendor/github.com/kballard/go-shellquote/quote.go
+++ b/vendor/github.com/kballard/go-shellquote/quote.go
@@ -1,0 +1,102 @@
+package shellquote
+
+import (
+	"bytes"
+	"strings"
+	"unicode/utf8"
+)
+
+// Join quotes each argument and joins them with a space.
+// If passed to /bin/sh, the resulting string will be split back into the
+// original arguments.
+func Join(args ...string) string {
+	var buf bytes.Buffer
+	for i, arg := range args {
+		if i != 0 {
+			buf.WriteByte(' ')
+		}
+		quote(arg, &buf)
+	}
+	return buf.String()
+}
+
+const (
+	specialChars      = "\\'\"`${[|&;<>()*?!"
+	extraSpecialChars = " \t\n"
+	prefixChars       = "~"
+)
+
+func quote(word string, buf *bytes.Buffer) {
+	// We want to try to produce a "nice" output. As such, we will
+	// backslash-escape most characters, but if we encounter a space, or if we
+	// encounter an extra-special char (which doesn't work with
+	// backslash-escaping) we switch over to quoting the whole word. We do this
+	// with a space because it's typically easier for people to read multi-word
+	// arguments when quoted with a space rather than with ugly backslashes
+	// everywhere.
+	origLen := buf.Len()
+
+	if len(word) == 0 {
+		// oops, no content
+		buf.WriteString("''")
+		return
+	}
+
+	cur, prev := word, word
+	atStart := true
+	for len(cur) > 0 {
+		c, l := utf8.DecodeRuneInString(cur)
+		cur = cur[l:]
+		if strings.ContainsRune(specialChars, c) || (atStart && strings.ContainsRune(prefixChars, c)) {
+			// copy the non-special chars up to this point
+			if len(cur) < len(prev) {
+				buf.WriteString(prev[0 : len(prev)-len(cur)-l])
+			}
+			buf.WriteByte('\\')
+			buf.WriteRune(c)
+			prev = cur
+		} else if strings.ContainsRune(extraSpecialChars, c) {
+			// start over in quote mode
+			buf.Truncate(origLen)
+			goto quote
+		}
+		atStart = false
+	}
+	if len(prev) > 0 {
+		buf.WriteString(prev)
+	}
+	return
+
+quote:
+	// quote mode
+	// Use single-quotes, but if we find a single-quote in the word, we need
+	// to terminate the string, emit an escaped quote, and start the string up
+	// again
+	inQuote := false
+	for len(word) > 0 {
+		i := strings.IndexRune(word, '\'')
+		if i == -1 {
+			break
+		}
+		if i > 0 {
+			if !inQuote {
+				buf.WriteByte('\'')
+				inQuote = true
+			}
+			buf.WriteString(word[0:i])
+		}
+		word = word[i+1:]
+		if inQuote {
+			buf.WriteByte('\'')
+			inQuote = false
+		}
+		buf.WriteString("\\'")
+	}
+	if len(word) > 0 {
+		if !inQuote {
+			buf.WriteByte('\'')
+		}
+		buf.WriteString(word)
+		buf.WriteByte('\'')
+	}
+}

--- a/vendor/github.com/kballard/go-shellquote/quote_test.go
+++ b/vendor/github.com/kballard/go-shellquote/quote_test.go
@@ -1,0 +1,31 @@
+package shellquote
+
+import (
+	"testing"
+)
+
+func TestSimpleJoin(t *testing.T) {
+	for _, elem := range simpleJoinTest {
+		output := Join(elem.input...)
+		if output != elem.output {
+			t.Errorf("Input %q, got %q, expected %q", elem.input, output, elem.output)
+		}
+	}
+}
+
+var simpleJoinTest = []struct {
+	input  []string
+	output string
+}{
+	{[]string{"test"}, "test"},
+	{[]string{"hello goodbye"}, "'hello goodbye'"},
+	{[]string{"hello", "goodbye"}, "hello goodbye"},
+	{[]string{"don't you know the dewey decimal system?"}, "'don'\\''t you know the dewey decimal system?'"},
+	{[]string{"don't", "you", "know", "the", "dewey", "decimal", "system?"}, "don\\'t you know the dewey decimal system\\?"},
+	{[]string{"~user", "u~ser", " ~user", "!~user"}, "\\~user u~ser ' ~user' \\!~user"},
+	{[]string{"foo*", "M{ovies,usic}", "ab[cd]", "%3"}, "foo\\* M\\{ovies,usic} ab\\[cd] %3"},
+	{[]string{"one", "", "three"}, "one '' three"},
+	{[]string{"some(parentheses)"}, "some\\(parentheses\\)"},
+	{[]string{"$some_ot~her_)spe!cial_*_characters"}, "\\$some_ot~her_\\)spe\\!cial_\\*_characters"},
+	{[]string{"' "}, "\\'' '"},
+}

--- a/vendor/github.com/kballard/go-shellquote/unquote.go
+++ b/vendor/github.com/kballard/go-shellquote/unquote.go
@@ -1,0 +1,156 @@
+package shellquote
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"unicode/utf8"
+)
+
+var (
+	UnterminatedSingleQuoteError = errors.New("Unterminated single-quoted string")
+	UnterminatedDoubleQuoteError = errors.New("Unterminated double-quoted string")
+	UnterminatedEscapeError      = errors.New("Unterminated backslash-escape")
+)
+
+var (
+	splitChars        = " \n\t"
+	singleChar        = '\''
+	doubleChar        = '"'
+	escapeChar        = '\\'
+	doubleEscapeChars = "$`\"\n\\"
+)
+
+// Split splits a string according to /bin/sh's word-splitting rules. It
+// supports backslash-escapes, single-quotes, and double-quotes. Notably it does
+// not support the $'' style of quoting. It also doesn't attempt to perform any
+// other sort of expansion, including brace expansion, shell expansion, or
+// pathname expansion.
+//
+// If the given input has an unterminated quoted string or ends in a
+// backslash-escape, one of UnterminatedSingleQuoteError,
+// UnterminatedDoubleQuoteError, or UnterminatedEscapeError is returned.
+func Split(input string) (words []string, err error) {
+	var buf bytes.Buffer
+	words = make([]string, 0)
+
+	for len(input) > 0 {
+		// skip any splitChars at the start
+		c, l := utf8.DecodeRuneInString(input)
+		if strings.ContainsRune(splitChars, c) {
+			input = input[l:]
+			continue
+		} else if c == escapeChar {
+			// Look ahead for escaped newline so we can skip over it
+			next := input[l:]
+			if len(next) == 0 {
+				err = UnterminatedEscapeError
+				return
+			}
+			c2, l2 := utf8.DecodeRuneInString(next)
+			if c2 == '\n' {
+				input = next[l2:]
+				continue
+			}
+		}
+
+		var word string
+		word, input, err = splitWord(input, &buf)
+		if err != nil {
+			return
+		}
+		words = append(words, word)
+	}
+	return
+}
+
+func splitWord(input string, buf *bytes.Buffer) (word string, remainder string, err error) {
+	buf.Reset()
+
+raw:
+	{
+		cur := input
+		for len(cur) > 0 {
+			c, l := utf8.DecodeRuneInString(cur)
+			cur = cur[l:]
+			if c == singleChar {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				input = cur
+				goto single
+			} else if c == doubleChar {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				input = cur
+				goto double
+			} else if c == escapeChar {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				input = cur
+				goto escape
+			} else if strings.ContainsRune(splitChars, c) {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				return buf.String(), cur, nil
+			}
+		}
+		if len(input) > 0 {
+			buf.WriteString(input)
+			input = ""
+		}
+		goto done
+	}
+
+escape:
+	{
+		if len(input) == 0 {
+			return "", "", UnterminatedEscapeError
+		}
+		c, l := utf8.DecodeRuneInString(input)
+		if c == '\n' {
+			// a backslash-escaped newline is elided from the output entirely
+		} else {
+			buf.WriteString(input[:l])
+		}
+		input = input[l:]
+	}
+	goto raw
+
+single:
+	{
+		i := strings.IndexRune(input, singleChar)
+		if i == -1 {
+			return "", "", UnterminatedSingleQuoteError
+		}
+		buf.WriteString(input[0:i])
+		input = input[i+1:]
+		goto raw
+	}
+
+double:
+	{
+		cur := input
+		for len(cur) > 0 {
+			c, l := utf8.DecodeRuneInString(cur)
+			cur = cur[l:]
+			if c == doubleChar {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				input = cur
+				goto raw
+			} else if c == escapeChar {
+				// bash only supports certain escapes in double-quoted strings
+				c2, l2 := utf8.DecodeRuneInString(cur)
+				cur = cur[l2:]
+				if strings.ContainsRune(doubleEscapeChars, c2) {
+					buf.WriteString(input[0 : len(input)-len(cur)-l-l2])
+					if c2 == '\n' {
+						// newline is special, skip the backslash entirely
+					} else {
+						buf.WriteRune(c2)
+					}
+					input = cur
+				}
+			}
+		}
+		return "", "", UnterminatedDoubleQuoteError
+	}
+
+done:
+	return buf.String(), input, nil
+}

--- a/vendor/github.com/kballard/go-shellquote/unquote_test.go
+++ b/vendor/github.com/kballard/go-shellquote/unquote_test.go
@@ -1,0 +1,55 @@
+package shellquote
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSimpleSplit(t *testing.T) {
+	for _, elem := range simpleSplitTest {
+		output, err := Split(elem.input)
+		if err != nil {
+			t.Errorf("Input %q, got error %#v", elem.input, err)
+		} else if !reflect.DeepEqual(output, elem.output) {
+			t.Errorf("Input %q, got %q, expected %q", elem.input, output, elem.output)
+		}
+	}
+}
+
+func TestErrorSplit(t *testing.T) {
+	for _, elem := range errorSplitTest {
+		_, err := Split(elem.input)
+		if err != elem.error {
+			t.Errorf("Input %q, got error %#v, expected error %#v", elem.input, err, elem.error)
+		}
+	}
+}
+
+var simpleSplitTest = []struct {
+	input  string
+	output []string
+}{
+	{"hello", []string{"hello"}},
+	{"hello goodbye", []string{"hello", "goodbye"}},
+	{"hello   goodbye", []string{"hello", "goodbye"}},
+	{"glob* test?", []string{"glob*", "test?"}},
+	{"don\\'t you know the dewey decimal system\\?", []string{"don't", "you", "know", "the", "dewey", "decimal", "system?"}},
+	{"'don'\\''t you know the dewey decimal system?'", []string{"don't you know the dewey decimal system?"}},
+	{"one '' two", []string{"one", "", "two"}},
+	{"text with\\\na backslash-escaped newline", []string{"text", "witha", "backslash-escaped", "newline"}},
+	{"text \"with\na\" quoted newline", []string{"text", "with\na", "quoted", "newline"}},
+	{"\"quoted\\d\\\\\\\" text with\\\na backslash-escaped newline\"", []string{"quoted\\d\\\" text witha backslash-escaped newline"}},
+	{"text with an escaped \\\n newline in the middle", []string{"text", "with", "an", "escaped", "newline", "in", "the", "middle"}},
+	{"foo\"bar\"baz", []string{"foobarbaz"}},
+}
+
+var errorSplitTest = []struct {
+	input string
+	error error
+}{
+	{"don't worry", UnterminatedSingleQuoteError},
+	{"'test'\\''ing", UnterminatedSingleQuoteError},
+	{"\"foo'bar", UnterminatedDoubleQuoteError},
+	{"foo\\", UnterminatedEscapeError},
+	{"   \\", UnterminatedEscapeError},
+}


### PR DESCRIPTION
Added support for providing optional additional options to `xcodebuild` via `xcodebuild_options`, similar to the existing [Xcode Archive step](https://github.com/bitrise-io/steps-xcode-archive) for iOS.

Mostly the same code taken from that step, and the same dependency added to be able to split the provided options string – `go-shellquote`.

This change was driven by the need to provide the option `CODE_SIGNING_REQUIRED=NO''` to `xcodebuild`.

I have successfully tested the changes both locally with the Bitrise CLI and online through the Bitrise dashboard.