### PR TITLE
Changed "build" action to "build-for-testing"

### DIFF
--- a/main.go
+++ b/main.go
@@ -107,7 +107,7 @@ func main() {
 	}
 
 	// build before test
-	buildAction = append(buildAction, "build")
+	buildAction = append(buildAction, "build-for-testing")
 
 	// setup CommandModel for test
 	testCommandModel := xcodebuild.NewTestCommand(cfgs.ProjectPath, (action == "-workspace"))


### PR DESCRIPTION
The build action will fail on schemes that are only for testing. build-for-testing will not fail on these schemes. Fixes #16

N.B. In testing, this fixes my issue when running bitriseCLI locally, but on the cloud build my particular project is still having issues. I am assuming they are unrelated to this issue for now.