### PR TITLE
remove unneeded dependencies property from step definition

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -10,9 +10,6 @@ project_type_tags:
 - macos
 type_tags:
 - test
-dependencies:
-- manager: _
-  name: xcode
 deps:
   check_only:
   - name: xcode


### PR DESCRIPTION
This step always throws a warning in Bitrise's runner log because it uses the dependencies property in step.yml. This check for xcode is already replicated in deps, so dependencies can be removed.