### PR TITLE
Code Signing cannot work for macOS Apps on CI

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -104,7 +104,7 @@ inputs:
     - xcpretty
     - xcodebuild
     is_required: true
-- xcodebuild_options: ""
+- xcodebuild_options: "CODE_SIGNING_ALLOWED='NO'"
   opts:
     title: Additional options for xcodebuild call
     description: |-


### PR DESCRIPTION
In order to test macOS Apps on CI where the Device ID is unknown in advance we need to disable code signing

### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

In order to test macOS Apps on CI where the Device ID is unknown in advance we need to disable code signing since a profile cannot be created for CI machines.

### Changes

Added default additional arg to the step input

### Investigation details

No automatic code signing options available

### Decisions

It is not possible to get code signing to work on CI machines due to the need to register macOS devices
