### PR TITLE
Use output_tool input of step

### DIFF
--- a/main.go
+++ b/main.go
@@ -72,17 +72,17 @@ func NewStep(logger logV2.Logger, xcpretty xcprettyinstaller.Installer) Step {
 	return Step{logger: logger, xcpretty: xcpretty}
 }
 
-func (s Step) selectLogFormatter() string {
-	outputTool := xcprettyFormatter
-
-	ver, err := s.xcpretty.Install()
-	if err != nil {
-		log.Warnf("Failed to ensure xcpretty log formatter: %s", err)
-		log.Printf("Switching to xcodebuild for output tool")
-		outputTool = xcodebuildFormatter
-	} else {
-		log.Printf("- xcpretty version: %s", ver.String())
-		fmt.Println()
+func (s Step) selectLogFormatter(outputTool string) string {
+	if outputTool == xcprettyFormatter {
+		ver, err := s.xcpretty.Install()
+		if err != nil {
+			log.Warnf("Failed to ensure xcpretty log formatter: %s", err)
+			log.Printf("Switching to xcodebuild for output tool")
+			return xcodebuildFormatter
+		} else {
+			log.Printf("- xcpretty version: %s", ver.String())
+			fmt.Println()
+		}
 	}
 
 	return outputTool
@@ -118,7 +118,7 @@ func (s Step) run() {
 	log.Printf("* xcodebuild_version: %s (%s)", xcodebuildVersion.Version, xcodebuildVersion.BuildVersion)
 
 	// xcpretty
-	cfgs.OutputTool = s.selectLogFormatter()
+	cfgs.OutputTool = s.selectLogFormatter(cfgs.OutputTool)
 
 	fmt.Println()
 

--- a/main_test.go
+++ b/main_test.go
@@ -17,7 +17,7 @@ func TestGivenStep_WhenXCPrettyInstallSucceeds_ThenOutputToolIsXCPretty(t *testi
 	xcpretty.On("Install").Return(&version.Version{}, nil)
 
 	step := NewStep(logger, xcpretty)
-	outputTool := step.selectLogFormatter()
+	outputTool := step.selectLogFormatter("xcpretty")
 	require.Equal(t, xcprettyFormatter, outputTool)
 }
 
@@ -28,6 +28,15 @@ func TestGivenStep_WhenXCPrettyInstallFails_ThenOutputToolIsXcodebuild(t *testin
 	xcpretty.On("Install").Return(nil, fmt.Errorf("install failed"))
 
 	step := NewStep(logger, xcpretty)
-	outputTool := step.selectLogFormatter()
+	outputTool := step.selectLogFormatter("xcpretty")
+	require.Equal(t, xcodebuildFormatter, outputTool)
+}
+
+func TestGivenStep_WhenXcodebuildOutputIsSelected_ThenOutputToolIsXcodebuild(t *testing.T) {
+	logger := new(mocks.Logger)
+	xcpretty := new(mocks.Installer)
+
+	step := NewStep(logger, xcpretty)
+	outputTool := step.selectLogFormatter("xcodebuild")
 	require.Equal(t, xcodebuildFormatter, outputTool)
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

The step now checks output_tool input & tries to proceed accordingly. It will only use a different output tool if the selected one is xcpretty & it fails to install. In such case - just like before - xcodebuild will be used.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
